### PR TITLE
Some custom mission order examples

### DIFF
--- a/documents/beta/custom_branching_paths.yaml
+++ b/documents/beta/custom_branching_paths.yaml
@@ -1,0 +1,69 @@
+﻿# Original author: Alice Voltaire (@AliceVoltaire)
+# Implementer: Salzkorn
+
+# This creates a mission order that looks like this:
+#
+#    [-][S][-]
+#    [X]   [X]
+# [-][-][-][-][-]
+# [X]   [X]   [X]
+# [-][-][-][-][-]
+#    [X]   [X]
+#    [-][G][-]
+#
+# S = Start, G = Goal, X = Locked
+
+  custom_mission_order:
+    Branching Paths:
+      type: grid
+      size: 35 # 5 * 7
+      width: 5
+      missions:
+      # Basic setup (holes, start, goal)
+      - index:
+        # Edges
+        - rect(0, 0, 1, 2)
+        - rect(4, 0, 1, 2)
+        - rect(0, 5, 1, 2)
+        - rect(4, 5, 1, 2)
+        # Inner holes
+        - point(2, 1)
+        - point(1, 3)
+        - point(3, 3)
+        - point(2, 5)
+        empty: true
+      - index: point(2, 0)
+        entrance: true
+      - index: point(2, 6)
+        exit: true
+      # Add keys
+      - index:
+        - point(1, 1)
+        - point(3, 1)
+        - point(0, 3)
+        - point(2, 3)
+        - point(4, 3)
+        - point(1, 5)
+        - point(3, 5)
+        entry_rules:
+        - items: { Key: 1 }
+      # Variant with rows sharing a key
+      # Remove or comment out the above key section if you want to use this
+      # This uses special key items that are exclusive to custom mission orders
+      # You can find a complete list of them in the Custom Mission Order docs
+      # - index:
+      #   - point(1, 1)
+      #   - point(3, 1)
+      #   entry_rules:
+      #   - items: { Raynor Key: 1 }
+      # - index:
+      #   - point(0, 3)
+      #   - point(2, 3)
+      #   - point(4, 3)
+      #   entry_rules:
+      #   - items: { Kerrigan Key: 1 }
+      # - index:
+      #   - point(1, 5)
+      #   - point(3, 5)
+      #   entry_rules:
+      #   - items: { Artanis Key: 1 }

--- a/documents/beta/custom_example_raceswap_campaigns.yaml
+++ b/documents/beta/custom_example_raceswap_campaigns.yaml
@@ -1,0 +1,40 @@
+﻿# Original author: Salzkorn
+
+# This is an example demonstrating how to use custom mission orders to create simple race-swapped campaigns.
+# As with all custom mission orders, this requires setting "mission_order: custom" in your YAML to work.
+
+# With all of the below, be wary of Zerg possibly not having enough missions to fill the longer campaigns.
+
+  custom_mission_order:
+    # This is a descriptive name for our custom campaign
+    Zerg WoL:
+      # This loads a campaign preset (see Custom Mission Order docs for a complete list, otherwise just use WoL/HotS/LotV/NCO and Mini variants)
+      preset: mini wol
+      # This sets default options for all the layouts in this campaign
+      global:
+        # This sets the allowed pool of missions for all layouts to be the "Zerg Missions" mission group
+        mission_pool: zerg missions
+
+    # Since multiple campaigns can be in the same mission order, if you want to use this example, make sure to remove the campaigns you don't want
+    T+Z LotV:
+      preset: lotv
+      global:
+        # You can use a list of mission groups to add them together
+        mission_pool:
+        - zerg missions
+        - terran missions
+
+    Protoss HotS with Keys:
+      preset: mini hots
+      # Campaign presets accept this keys option, similar to the key_mode option for regular mission orders
+      # "keys: missions" adds a key to every mission
+      # "keys: layouts" adds a key to every layout
+      keys: missions
+      global:
+        # You can use ~ to remove a mission group from the pool
+        # The following makes a pool of Protoss missions, then removes all no-build and race-swap missions
+        # See the docs for a complete list of instructions for mission pools
+        mission_pool:
+          - protoss missions
+          - ~ no-build missions
+          - ~ raceswap missions

--- a/documents/beta/custom_example_short_campaign.yaml
+++ b/documents/beta/custom_example_short_campaign.yaml
@@ -1,0 +1,58 @@
+﻿# Original author: Salzkorn
+
+# This is an example using various features of custom mission orders to create a short campaign.
+# As with all custom mission orders, this requires setting "mission_order: custom" in your YAML to work.
+
+# Custom mission orders have the following basic format:
+#
+# custom_mission_order:
+#   <campaign name>:
+#     some_campaign_option: value
+#     <layout name>:
+#       # Layouts always require a type and size
+#       type: grid
+#       size: 4
+#       some_layout_option: value
+#
+# Campaigns can contain multiple layouts, and the mission order can contain multiple campaigns.
+
+# For more details on available options, please see the Custom Mission Order documentation.
+
+  custom_mission_order:
+    Archipelago!:
+      max_difficulty: hard # This limits the campaign to end with hard missions
+      Victory Island:
+        type: grid
+        size: 4
+        exit: true # This makes this layout the campaign's goal (the default is the last layout)
+        missions: # This modifies mission slots directly
+          - index: [1, 2] # On a size 4 grid these are the top right and bottom left slots
+            entry_rules:
+              # This entry rule requires beating 4 mission from the Archipelago! campaign
+              - scope: Archipelago!
+                amount: 4
+          - index: 3
+            entry_rules:
+              - scope: Archipelago!
+                amount: 7
+      Zerg Atoll:
+        type: column
+        size: 2
+        entry_rules:
+          # This entry rule requires beating the exact mission at index 0 in the Victory Island layout in this campaign
+          # Index 0 is usually the default entrance (or starter mission) of a layout
+          - scope: ../Victory Island/0
+        # This sets the possible mission for this layout to be only missions from the "Zerg Missions" mission group
+        mission_pool: zerg missions
+      Terran Cove:
+        type: column
+        size: 2
+        entry_rules:
+          - scope: ../Victory Island/0
+        mission_pool: terran missions
+      Protoss Peninsula:
+        type: column
+        size: 2
+        entry_rules:
+          - scope: ../Victory Island/0
+        mission_pool: protoss missions

--- a/documents/beta/custom_forked_path.yaml
+++ b/documents/beta/custom_forked_path.yaml
@@ -1,0 +1,44 @@
+﻿# Original author: Sraw
+# Implementer: Salzkorn
+
+# This creates a mission order that looks like this:
+#
+#       [-][X][-][X]
+#    [-][X][-]   [-]
+# [-][S]         [G]
+#    [-][X][-]   [-]
+#       [-][X][-][X]
+#
+# S = Start, G = Goal, X = Locked
+
+  custom_mission_order:
+    Forked Path:
+      type: grid
+      size: 30 # 6 * 5
+      width: 6
+      missions:
+      # Basic setup (holes, start, goal)
+      - index:
+        # Outside
+        - rect(0, 0, 2, 1)
+        - point(0, 1)
+        - rect(0, 4, 2, 1)
+        - point(0, 3)
+        # Inside
+        - rect(2, 2, 2, 1)
+        - rect(4, 1, 1, 3)
+        empty: true
+      - index: point(1, 2)
+        entrance: true
+      - index: point(5, 2)
+        exit: true
+      # Add keys
+      - index:
+        - point(2, 1)
+        - point(2, 3)
+        - point(3, 0)
+        - point(3, 4)
+        - point(5, 0)
+        - point(5, 4)
+        entry_rules:
+        - items: { Key: 1 }

--- a/documents/beta/custom_sc2_logo.yaml
+++ b/documents/beta/custom_sc2_logo.yaml
@@ -1,0 +1,59 @@
+# Original author: Salzkorn
+
+# This creates a mission order that looks like this:
+#
+#                [S][-]   [-][S]
+# [-][-][-][-][S]   [-]   [-]   [-][-][-][-][S]
+# [-][-]            [-]   [-]   [-]
+#    [-][-]         [-]   [-]   [-]
+#       [-][-]      [-]   [-]   [-][-]
+# [G][-][-][-][-]   [-]   [-]      [-][-][-][G]
+#                [G][-]   [-][G]
+#
+# S = Start, G = Goal
+
+  custom_mission_order:
+    SC2 Logo:
+      type: grid
+      size: 105 # 7 * 15
+      width: 15
+      missions:
+      # start with an empty canvas
+      - index: all
+        empty: true
+      - index: # S
+        - rect(0, 1, 5, 1)
+        - rect(0, 2, 2, 1)
+        - rect(1, 3, 2, 1)
+        - rect(2, 4, 2, 1)
+        - rect(0, 5, 5, 1)
+        empty: false
+        mission_pool: zerg missions
+      - index: # C
+        - rect(10, 1, 5, 1)
+        - rect(10, 2, 1, 3)
+        - point(11, 4)
+        - rect(11, 5, 4, 1)
+        empty: false
+        mission_pool: protoss missions
+      - index: # II
+        - rect(6, 0, 1, 7)
+        - rect(8, 0, 1, 7)
+        - point(5, 0)
+        - point(9, 0)
+        - point(5, 6)
+        - point(9, 6)
+        empty: false
+        mission_pool: terran missions
+      - index: # entrances
+        - point(4, 1)
+        - point(5, 0)
+        - point(9, 0)
+        - point(14, 1)
+        entrance: true
+      - index: # exits
+        - point(0, 5)
+        - point(5, 6)
+        - point(9, 6)
+        - point(14, 5)
+        exit: true


### PR DESCRIPTION
This adds 5 examples for custom mission orders:
- `custom_example_raceswap_campaigns` shows how to make simple race-swapped campaigns
- `custom_example_short_campaign` shows how to use some more complicated features to make a custom campaign
- `custom_sc2_logo` is an order I made to test drawing on a grid, it's functionally just 4 separate linear paths but looks cool
- `custom_branching_paths` and `custom_forked_path` were taken from people on the Discord

The last two and one of the race-swap examples use keys, so they're made for and tested on the [key mode PR](https://github.com/Ziktofel/Archipelago/pull/300)'s branch.